### PR TITLE
chore(build): fix build binaries

### DIFF
--- a/scripts/build_extension.sh
+++ b/scripts/build_extension.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/zsh
+#!/bin/bash
 
 go build
 GOOS=windows GOARCH=amd64 go build -o gh-peruse-windows-amd64.exe


### PR DESCRIPTION
Seems zsh isn't on Github runners, whoops. Bash is though!