### PR TITLE
chore(build): supply token to gh cli

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,3 +30,5 @@ jobs:
         run: ./scripts/build_extension.sh
       - name: Create release
         run: gh release create $NEXT_VERSION --latest -F release_notes.txt ./*amd64*
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Thought it would pickup the secret but nope. Really wish I'd not set the workflow dependency and branch restriction and let it run on a branch first now!