### PR TITLE
feat: allow checking owned PRs for new comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,17 @@ For full up-to-date flags:
 
 `git peruse pr -h`
 
+### Notifications for new comments
+
+If you'd like to receive a system notification when you have new comments on PRs you own you can add the following to a job that runs on a schedule e.g. via [cron](https://en.wikipedia.org/wiki/Cron) or [Windows Task Scheduler](https://en.wikipedia.org/wiki/Windows_Task_Scheduler)
+
+#### Using Github CLI
+
+`gh peruse pr check -n`
+
+#### Using Git
+
+`git peruse pr check -n`
 
 ## Developing
 

--- a/cmd/pr/internal/new_comments/check.go
+++ b/cmd/pr/internal/new_comments/check.go
@@ -1,0 +1,44 @@
+package new_comments
+
+import (
+	"fmt"
+
+	"github.com/hbk619/gh-peruse/internal/filesystem"
+	"github.com/hbk619/gh-peruse/internal/git"
+	"github.com/hbk619/gh-peruse/internal/github"
+	"github.com/hbk619/gh-peruse/internal/history"
+)
+
+func CheckForNewComments(prClient github.PullRequestClient, historyService history.Storage, output filesystem.Output) error {
+	repo, err := prClient.GetRepoDetails()
+	if err != nil {
+		return fmt.Errorf("failed to get repo info %w", err)
+	}
+	internalRepo := &git.Repo{
+		Owner: repo.Owner,
+		Name:  repo.Name,
+	}
+	prs, err := prClient.GetCommentCountForOwnedPRs(internalRepo)
+	if err != nil {
+		return fmt.Errorf("failed to get prs %w", err)
+	}
+
+	prHistory, err := historyService.Load()
+	if err != nil {
+		return fmt.Errorf("failed to load comments from history: %w", err)
+	}
+
+	var notifyError error
+	for pr, count := range prs {
+		oldCount := prHistory.Prs[pr].CommentCount
+		if oldCount != count {
+			msg := fmt.Sprintf("Pull request %d has new comments", pr)
+			err = output.Println(msg)
+			if err != nil {
+				notifyError = err
+			}
+
+		}
+	}
+	return notifyError
+}

--- a/cmd/pr/internal/new_comments/check_test.go
+++ b/cmd/pr/internal/new_comments/check_test.go
@@ -1,0 +1,120 @@
+package new_comments
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/cli/go-gh/v2/pkg/repository"
+	"github.com/golang/mock/gomock"
+	mock_filesystem "github.com/hbk619/gh-peruse/internal/filesystem/mocks"
+	"github.com/hbk619/gh-peruse/internal/git"
+	mock_github "github.com/hbk619/gh-peruse/internal/github/mocks"
+	"github.com/hbk619/gh-peruse/internal/history"
+	mock_history "github.com/hbk619/gh-peruse/internal/history/mocks"
+	"github.com/stretchr/testify/suite"
+)
+
+type CheckNewComments struct {
+	suite.Suite
+	ctrl         *gomock.Controller
+	mockHistory  *mock_history.MockStorage
+	mockOutput   *mock_filesystem.MockOutput
+	mockPrClient *mock_github.MockPullRequestClient
+	repo         repository.Repository
+	gitRepo      *git.Repo
+}
+
+func (suite *CheckNewComments) BeforeTest(string, string) {
+	suite.ctrl = gomock.NewController(suite.T())
+	suite.mockOutput = mock_filesystem.NewMockOutput(suite.ctrl)
+	suite.mockHistory = mock_history.NewMockStorage(suite.ctrl)
+	suite.mockPrClient = mock_github.NewMockPullRequestClient(suite.ctrl)
+	suite.repo = repository.Repository{
+		Owner: "luigi",
+		Name:  "mansion",
+	}
+	suite.gitRepo = &git.Repo{
+		Owner: "luigi",
+		Name:  "mansion",
+	}
+}
+
+func (suite *CheckNewComments) TestCheckForNewComments_finds_comments() {
+	suite.mockPrClient.EXPECT().GetRepoDetails().Return(suite.repo, nil)
+	suite.mockPrClient.EXPECT().GetCommentCountForOwnedPRs(suite.gitRepo).
+		Return(map[int]int{
+			2: 3,
+			1: 7,
+			3: 1,
+		}, nil)
+	suite.mockHistory.EXPECT().Load().Return(history.History{
+		Prs: map[int]history.PR{
+			2: history.PR{
+				CommentCount: 2,
+			},
+			3: history.PR{
+				CommentCount: 1,
+			},
+		},
+	}, nil)
+	suite.mockOutput.EXPECT().Println("Pull request 1 has new comments")
+	suite.mockOutput.EXPECT().Println("Pull request 2 has new comments")
+
+	err := CheckForNewComments(suite.mockPrClient, suite.mockHistory, suite.mockOutput)
+	suite.NoError(err)
+}
+
+func (suite *CheckNewComments) TestCheckForNewComments_returns_errors_from_fetching_comment_count() {
+	suite.mockPrClient.EXPECT().GetRepoDetails().Return(suite.repo, nil)
+	suite.mockPrClient.EXPECT().GetCommentCountForOwnedPRs(suite.gitRepo).Return(nil, errors.New("failed to get comments"))
+
+	err := CheckForNewComments(suite.mockPrClient, suite.mockHistory, suite.mockOutput)
+	suite.ErrorContains(err, "failed to get comments")
+}
+
+func (suite *CheckNewComments) TestCheckForNewComments_returns_errors_from_fetching_history() {
+	suite.mockPrClient.EXPECT().GetRepoDetails().Return(suite.repo, nil)
+	suite.mockPrClient.EXPECT().GetCommentCountForOwnedPRs(suite.gitRepo).
+		Return(map[int]int{
+			2: 3,
+			1: 7,
+			3: 1,
+		}, nil)
+	suite.mockHistory.EXPECT().Load().Return(history.History{}, errors.New("failed to get history"))
+
+	err := CheckForNewComments(suite.mockPrClient, suite.mockHistory, suite.mockOutput)
+	suite.ErrorContains(err, "failed to get history")
+}
+func (suite *CheckNewComments) TestCheckForNewComments_returns_errors_from_output() {
+	suite.mockPrClient.EXPECT().GetRepoDetails().Return(suite.repo, nil)
+	suite.mockPrClient.EXPECT().GetCommentCountForOwnedPRs(suite.gitRepo).
+		Return(map[int]int{
+			2: 3,
+			1: 7,
+			3: 1,
+		}, nil)
+	suite.mockHistory.EXPECT().Load().Return(history.History{
+		Prs: map[int]history.PR{
+			2: history.PR{
+				CommentCount: 2,
+			},
+			3: history.PR{
+				CommentCount: 1,
+			},
+		},
+	}, nil)
+	suite.mockOutput.EXPECT().Println("Pull request 1 has new comments").Return(errors.New("failed to print"))
+	suite.mockOutput.EXPECT().Println("Pull request 2 has new comments")
+	err := CheckForNewComments(suite.mockPrClient, suite.mockHistory, suite.mockOutput)
+	suite.ErrorContains(err, "failed to print")
+}
+func (suite *CheckNewComments) TestCheckForNewComments_returns_errors_from_repo() {
+	suite.mockPrClient.EXPECT().GetRepoDetails().Return(repository.Repository{}, errors.New("bad repo"))
+
+	err := CheckForNewComments(suite.mockPrClient, suite.mockHistory, suite.mockOutput)
+	suite.ErrorContains(err, "bad repo")
+}
+
+func TestCheckNewCommentsSuite(t *testing.T) {
+	suite.Run(t, new(CheckNewComments))
+}

--- a/cmd/pr/internal/pr_action.go
+++ b/cmd/pr/internal/pr_action.go
@@ -93,39 +93,38 @@ func (pr *PRAction) getPRNumber(args []string) (int, error) {
 func (pr *PRAction) updateHistory(prNumber int, commentCount int) {
 	prHistory, err := pr.history.Load()
 	if err != nil {
-		pr.output.Println(fmt.Sprintf("Warning failed to load comments to history: %s", err.Error()))
+		_ = pr.output.Println(fmt.Sprintf("Warning failed to load comments to history: %s", err.Error()))
+		return
 	}
 
-	if err == nil {
-		existingPrHistory := prHistory.Prs[prNumber]
-		if existingPrHistory.CommentCount != commentCount {
-			pr.output.Println("New comments ahead!")
-		}
+	existingPrHistory := prHistory.Prs[prNumber]
+	if existingPrHistory.CommentCount != commentCount {
+		_ = pr.output.Println("New comments ahead!")
+	}
 
-		existingPrHistory.CommentCount = commentCount
-		prHistory.Prs[prNumber] = existingPrHistory
-		err = pr.history.Save(prHistory)
-		if err != nil {
-			pr.output.Println(fmt.Sprintf("Warning failed to save comments to history: %s", err.Error()))
-		}
+	existingPrHistory.CommentCount = commentCount
+	prHistory.Prs[prNumber] = existingPrHistory
+	err = pr.history.Save(prHistory)
+	if err != nil {
+		_ = pr.output.Println(fmt.Sprintf("Warning failed to save comments to history: %s", err.Error()))
 	}
 }
 
 func (pr *PRAction) Reply(contents string) {
 	err := pr.client.Reply(contents, &pr.Results[pr.Interactive.Index], pr.Id)
 	if err != nil {
-		pr.output.Println(fmt.Sprintf("Warning failed to comment: %s", err.Error()))
+		_ = pr.output.Println(fmt.Sprintf("Warning failed to comment: %s", err.Error()))
 	} else {
-		pr.output.Println("Posted comment")
+		_ = pr.output.Println("Posted comment")
 	}
 }
 
 func (pr *PRAction) Resolve() {
 	err := pr.client.Resolve(&pr.Results[pr.Interactive.Index])
 	if err != nil {
-		pr.output.Println(fmt.Sprintf("Warning failed to resolve thread: %s", err.Error()))
+		_ = pr.output.Println(fmt.Sprintf("Warning failed to resolve thread: %s", err.Error()))
 	} else {
-		pr.output.Println("Conversation resolved")
+		_ = pr.output.Println("Conversation resolved")
 	}
 }
 
@@ -159,7 +158,7 @@ func (pr *PRAction) Run() {
 		case "q":
 			os.Exit(0)
 		default:
-			pr.output.Println("Invalid choice")
+			_ = pr.output.Println("Invalid choice")
 		}
 
 	}
@@ -168,11 +167,11 @@ func (pr *PRAction) Run() {
 func (pr *PRAction) Print() {
 	current := pr.Results[pr.Interactive.Index]
 	if current.Thread.IsResolved {
-		pr.output.Println("This comment is resolved")
+		_ = pr.output.Println("This comment is resolved")
 		return
 	}
 	if current.Outdated {
-		pr.output.Println("This comment is outdated")
+		_ = pr.output.Println("This comment is outdated")
 		return
 	}
 	pr.printContents(current)
@@ -180,24 +179,24 @@ func (pr *PRAction) Print() {
 
 func (pr *PRAction) printContents(current git.Comment) {
 	if pr.LastFullPath != current.File.FullPath {
-		pr.output.Println(current.File.FileName)
+		_ = pr.output.Println(current.File.FileName)
 		if current.File.Path != "" {
-			pr.output.Println(current.File.Path)
-			pr.output.Println(strconv.Itoa(current.File.Line))
-			pr.output.Println(current.File.LineContents)
+			_ = pr.output.Println(current.File.Path)
+			_ = pr.output.Println(strconv.Itoa(current.File.Line))
+			_ = pr.output.Println(current.File.LineContents)
 		}
 	}
-	pr.output.Println(current.Author.Login)
-	pr.output.Println(current.Body)
+	_ = pr.output.Println(current.Author.Login)
+	_ = pr.output.Println(current.Body)
 }
 
 func (pr *PRAction) PrintState() {
-	pr.output.Println(pr.State.MergeStatus)
-	pr.output.Println(pr.State.ConflictStatus)
+	_ = pr.output.Println(pr.State.MergeStatus)
+	_ = pr.output.Println(pr.State.ConflictStatus)
 	for reviewState, names := range pr.State.Reviews {
-		pr.output.Println(fmt.Sprintf("%s %s", reviewState, strings.Join(names, " ")))
+		_ = pr.output.Println(fmt.Sprintf("%s %s", reviewState, strings.Join(names, " ")))
 	}
 	for _, status := range pr.State.Statuses {
-		pr.output.Println(fmt.Sprintf("Check %s %s", status.Name, status.Conclusion))
+		_ = pr.output.Println(fmt.Sprintf("Check %s %s", status.Name, status.Conclusion))
 	}
 }

--- a/cmd/pr/main.go
+++ b/cmd/pr/main.go
@@ -1,7 +1,0 @@
-package main
-
-import "github.com/hbk619/gh-peruse/cmd/pr/cmd"
-
-func main() {
-	cmd.Execute()
-}

--- a/internal/filesystem/mocks/output.go
+++ b/internal/filesystem/mocks/output.go
@@ -34,9 +34,11 @@ func (m *MockOutput) EXPECT() *MockOutputMockRecorder {
 }
 
 // Print mocks base method.
-func (m *MockOutput) Print(text string) {
+func (m *MockOutput) Print(text string) error {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "Print", text)
+	ret := m.ctrl.Call(m, "Print", text)
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
 // Print indicates an expected call of Print.
@@ -46,9 +48,11 @@ func (mr *MockOutputMockRecorder) Print(text interface{}) *gomock.Call {
 }
 
 // Println mocks base method.
-func (m *MockOutput) Println(text string) {
+func (m *MockOutput) Println(text string) error {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "Println", text)
+	ret := m.ctrl.Call(m, "Println", text)
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
 // Println indicates an expected call of Println.

--- a/internal/filesystem/output.go
+++ b/internal/filesystem/output.go
@@ -4,8 +4,8 @@ import "fmt"
 
 type (
 	Output interface {
-		Println(text string)
-		Print(text string)
+		Println(text string) error
+		Print(text string) error
 	}
 
 	StdOut struct{}
@@ -15,10 +15,12 @@ func NewStdOut() *StdOut {
 	return &StdOut{}
 }
 
-func (stdOut *StdOut) Println(text string) {
+func (stdOut *StdOut) Println(text string) error {
 	fmt.Println(text)
+	return nil
 }
 
-func (stdOut *StdOut) Print(text string) {
+func (stdOut *StdOut) Print(text string) error {
 	fmt.Print(text)
+	return nil
 }

--- a/internal/git/api.go
+++ b/internal/git/api.go
@@ -134,4 +134,14 @@ type (
 	GitHubData struct {
 		Repository Repository
 	}
+
+	GithubPREdge struct {
+		Node PullRequest
+	}
+	GithubSearch struct {
+		Edges []GithubPREdge
+	}
+	GithubQuery struct {
+		Search GithubSearch
+	}
 )

--- a/internal/github/graphql/pr_query.go
+++ b/internal/github/graphql/pr_query.go
@@ -2,6 +2,8 @@ package graphql
 
 import (
 	"fmt"
+
+	"github.com/hbk619/gh-peruse/internal/git"
 )
 
 func PRDetailsQuery(verbose bool) string {
@@ -107,3 +109,53 @@ var GetPRForBranch = `query GetPRForBranch($BranchName: String!, $Owner: String!
     }
   }
 }`
+
+func GetAllPRsFor(repo *git.Repo) string {
+	repoUrl := fmt.Sprintf("%s/%s", repo.Owner, repo.Name)
+	return fmt.Sprintf(`query {
+    search(
+      type: ISSUE,
+      query: "repo:%s author:@me state:open is:pr",
+      first: 20
+    ) {
+      edges {
+        node {
+          ... on PullRequest {
+          id
+          number
+          commits(first: 100) {
+            nodes {
+              commit {
+                comments(first: 100) {
+                  nodes {
+                    body
+                  }
+                }
+              }
+            }
+          }
+          reviews(first: 100) {
+            nodes {
+                body
+              }
+          }
+          reviewThreads(first: 100) {
+            nodes {
+              comments(first: 100) {
+                nodes {
+                  body
+                }
+              }
+            }
+          }
+          comments(first: 100) {
+            nodes {
+              body
+            }
+          }
+        }
+      }
+    }
+  }
+}`, repoUrl)
+}

--- a/internal/github/mocks/pr_client.go
+++ b/internal/github/mocks/pr_client.go
@@ -50,6 +50,21 @@ func (mr *MockPullRequestClientMockRecorder) DetectCurrentPR(repo interface{}) *
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DetectCurrentPR", reflect.TypeOf((*MockPullRequestClient)(nil).DetectCurrentPR), repo)
 }
 
+// GetCommentCountForOwnedPRs mocks base method.
+func (m *MockPullRequestClient) GetCommentCountForOwnedPRs(repo *git.Repo) (map[int]int, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetCommentCountForOwnedPRs", repo)
+	ret0, _ := ret[0].(map[int]int)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetCommentCountForOwnedPRs indicates an expected call of GetCommentCountForOwnedPRs.
+func (mr *MockPullRequestClientMockRecorder) GetCommentCountForOwnedPRs(repo interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCommentCountForOwnedPRs", reflect.TypeOf((*MockPullRequestClient)(nil).GetCommentCountForOwnedPRs), repo)
+}
+
 // GetPRDetails mocks base method.
 func (m *MockPullRequestClient) GetPRDetails(repo *git.Repo, verbose bool) (*git.PR, error) {
 	m.ctrl.T.Helper()

--- a/internal/notifications/notification.go
+++ b/internal/notifications/notification.go
@@ -1,0 +1,26 @@
+package notifications
+
+import (
+	"fmt"
+
+	"github.com/hbk619/gh-peruse/internal/requests"
+)
+
+type Notifier struct{}
+
+func NewNotifier() *Notifier {
+	return &Notifier{}
+}
+
+func (notifier *Notifier) Println(message string) error {
+	command := requests.NewCommandRunner()
+	err := Notify(message, command)
+	if err != nil {
+		return fmt.Errorf("error notifying %w", err)
+	}
+	return nil
+}
+
+func (notifier *Notifier) Print(message string) error {
+	return notifier.Println(message)
+}

--- a/internal/notifications/notify_linux.go
+++ b/internal/notifications/notify_linux.go
@@ -1,0 +1,23 @@
+//go:build linux
+// +build linux
+
+package notifications
+
+import (
+	"fmt"
+
+	"github.com/hbk619/gh-peruse/internal/requests"
+)
+
+func Notify(message string, command requests.CommandLine) error {
+	result, err := command.Run("notify-send", []string{message})
+	if err != nil {
+		return err
+	}
+
+	if result != "" {
+		return fmt.Errorf("failed to notify %w", err)
+	}
+
+	return nil
+}

--- a/internal/notifications/notify_mac.go
+++ b/internal/notifications/notify_mac.go
@@ -1,0 +1,23 @@
+//go:build darwin
+// +build darwin
+
+package notifications
+
+import (
+	"fmt"
+
+	"github.com/hbk619/gh-peruse/internal/requests"
+)
+
+func Notify(message string, command requests.CommandLine) error {
+	result, err := command.Run("osascript", []string{"-e", fmt.Sprintf("display notification \"%s\"", message)})
+	if err != nil {
+		return err
+	}
+
+	if result != "" {
+		return fmt.Errorf("failed to notify %w", err)
+	}
+
+	return nil
+}

--- a/internal/notifications/notify_windows.go
+++ b/internal/notifications/notify_windows.go
@@ -1,0 +1,23 @@
+//go:build windows
+// +build windows
+
+package notifications
+
+import (
+	"fmt"
+
+	"github.com/hbk619/gh-peruse/internal/requests"
+)
+
+func Notify(message string, command requests.CommandLine) error {
+	result, err := command.Run("msg", []string{"*", "/TIME:3", message})
+	if err != nil {
+		return err
+	}
+
+	if result != "" {
+		return fmt.Errorf("failed to notify %w", err)
+	}
+
+	return nil
+}

--- a/internal/prompt.go
+++ b/internal/prompt.go
@@ -28,7 +28,7 @@ func (prompt *Prompter) String(label string) string {
 	var s string
 	r := bufio.NewReader(prompt.input)
 	for {
-		prompt.output.Print(label + ": ")
+		_ = prompt.output.Print(label + ": ")
 		s, _ = r.ReadString('\n')
 		if s != "" {
 			break

--- a/internal/requests/command_line.go
+++ b/internal/requests/command_line.go
@@ -1,0 +1,39 @@
+package requests
+
+import (
+	"bytes"
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+type (
+	CommandLine interface {
+		Run(executable string, args []string) (string, error)
+	}
+
+	CommandRunner struct{}
+)
+
+func NewCommandRunner() *CommandRunner {
+	return &CommandRunner{}
+}
+
+func (runner *CommandRunner) Run(executable string, args []string) (string, error) {
+	executablePath, err := exec.LookPath(executable)
+	if err != nil {
+		return "", err
+	}
+	var out bytes.Buffer
+	var errorPipe bytes.Buffer
+
+	cmd := exec.Command(executablePath, args...)
+	cmd.Stdout = &out
+	cmd.Stderr = &errorPipe
+
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("%s %w", errorPipe.String(), err)
+	}
+
+	return strings.TrimSpace(out.String()), nil
+}


### PR DESCRIPTION
Using the `peruse pr check` command you can list all PRs that have new comments since you last looks, also `-n` will show a notification so it can be used in a scheduled job